### PR TITLE
Started Deprecation of signals

### DIFF
--- a/notifications/apps.py
+++ b/notifications/apps.py
@@ -5,7 +5,7 @@ from django.apps import AppConfig
 
 class NotificationsConfig(AppConfig):
     """App Config."""
-    
+
     name = 'notifications'
 
     def ready(self):

--- a/notifications/signals.py
+++ b/notifications/signals.py
@@ -1,5 +1,7 @@
 """Defines and listens to notification signals."""
 
+import warnings
+
 from django.dispatch import Signal, receiver
 
 from . import NotificationError
@@ -17,6 +19,12 @@ read = Signal(providing_args=('notify_id', 'recipient'))
 @receiver(notify)
 def create_notification(**kwargs):
     """Notify signal receiver."""
+    warnings.warn(
+        'The \'notify\' Signal will be removed in 2.6.5 '
+        'Please use the helper functions in notifications.utils',
+        PendingDeprecationWarning
+    )
+
     # make fresh copy and retain kwargs
     params = kwargs.copy()
     del params['signal']
@@ -45,6 +53,12 @@ def read_notification(**kwargs):
     Raises NotificationError if the user doesn't have access
     to read the notification
     """
+    warnings.warn(
+        'The \'read\' Signal will be removed in 2.6.5 '
+        'Please use the helper functions in notifications.utils',
+        PendingDeprecationWarning
+    )
+
     notify_id = kwargs['notify_id']
     recipient = kwargs['recipient']
     notification = Notification.objects.get(id=notify_id)

--- a/notifications/tests/test_signals.py
+++ b/notifications/tests/test_signals.py
@@ -3,9 +3,9 @@
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 
-from . import NotificationError
-from .models import Notification
-from .signals import read, notify
+from .. import NotificationError
+from ..models import Notification
+from ..signals import read, notify
 
 
 class GeneralTestCase(TestCase):

--- a/notifications/tests/tests.py
+++ b/notifications/tests/tests.py
@@ -1,0 +1,222 @@
+"""Tests."""
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from .. import NotificationError
+from ..models import Notification
+from ..utils import notify, read
+
+
+class GeneralTestCase(TestCase):
+    """Tests for General functionality."""
+
+    User = get_user_model()
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create Users."""
+        cls.user1 = cls.User.objects.create_user(
+            username='user1@gmail.com', password='password'
+        )
+
+        cls.user2 = cls.User.objects.create(
+            username='user2@gmail.com', password='password'
+        )
+
+    def test_to_json_without_extra_data(self):
+        """
+        If the extra_data argument is ommitted,
+
+        the default should be an empty dictionary
+        """
+        # Create notification
+        notification = Notification.objects.create(
+            source=self.user2, source_display_name='User 2',
+            recipient=self.user1, action='Notified',
+            category='General notification', obj=1, url='http://example.com',
+            short_description='Short Description', is_read=False,
+        )
+
+        self.assertEqual(
+            notification.to_json(),
+            {
+                'source': self.user2.id, 'source_display_name': 'User 2',
+                'recipient': self.user1.id, 'action': 'Notified',
+                'category': 'General notification', 'obj': 1,
+                'short_description': 'Short Description',
+                'extra_data': {}, 'channels': '',
+                'url': 'http://example.com', 'is_read': False
+            }
+        )
+
+    def test_to_json_with_extra_data(self):
+        """Test to_json method with extra data."""
+        notification = Notification.objects.create(
+            source=self.user2, source_display_name='User 2',
+            recipient=self.user1, action='Notified',
+            category='General notification', obj=1, url='http://example.com',
+            short_description='Short Description', is_read=False,
+            extra_data={'hello': 'world'}
+        )
+
+        self.assertEqual(
+            notification.to_json(),
+            {
+                'source': self.user2.id, 'source_display_name': 'User 2',
+                'recipient': self.user1.id, 'action': 'Notified',
+                'category': 'General notification', 'obj': 1,
+                'short_description': 'Short Description', 'channels': '',
+                'url': 'http://example.com', 'extra_data': {'hello': 'world'},
+                'is_read': False,
+            }
+        )
+
+
+class NotificationSignalTestCase(TestCase):
+    """Tests for the notification signals."""
+
+    User = get_user_model()
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create Users."""
+        cls.user1 = cls.User.objects.create_user(
+            username='user1@gmail.com', password='password'
+        )
+
+        cls.user2 = cls.User.objects.create(
+            username='user2@gmail.com', password='password'
+        )
+
+    def test_user_cant_read_others_notifications(self):
+        """A user should only be able to read THEIR notifications."""
+        # Create Notification for User2
+        notification = Notification.objects.create(
+            source=self.user1, source_display_name='User 1',
+            recipient=self.user2, action='Notified',
+            category='General notification', obj=1, url='http://example.com',
+            is_read=False
+        )
+
+        # Try and Read the notification as User1
+        self.assertRaises(
+            NotificationError,
+            read, notify_id=notification.id, recipient=self.user1
+        )
+
+    def test_user_can_read_notifications(self):
+        """A user can read their notification"""
+        # Create Notification for User1
+        notification = Notification.objects.create(
+            source=self.user2, source_display_name='User 2',
+            recipient=self.user1, action='Notified',
+            category='General notification', obj=1, url='http://example.com',
+            is_read=False
+        )
+
+        # Try and Read the notification as user1
+        read(notify_id=notification.id, recipient=self.user1)
+
+        notification.refresh_from_db()
+        self.assertEqual(notification.is_read, True)
+
+    def test_silent_notification(self):
+        """Test Silent notifications."""
+        notify(
+            source=self.user2, source_display_name='User 2',
+            recipient=self.user1, action='Notified',
+            category='Silent notification', obj=1, url='http://example.com',
+            short_description='Short Description', is_read=False, silent=True,
+            channels=('console',)
+        )
+
+        notifications = Notification.objects.all()
+
+        self.assertEqual(tuple(notifications), tuple())
+
+
+class JSONFieldTestCase(TestCase):
+    """Test the Custom JSONField."""
+
+    User = get_user_model()
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create Users."""
+        cls.user1 = cls.User.objects.create_user(
+            username='user1@gmail.com', password='password'
+        )
+
+        cls.user2 = cls.User.objects.create(
+            username='user2@gmail.com', password='password'
+        )
+
+    def test_raise_exception(self):
+        """
+        Should raise an exception
+
+        When we try to save objects that can be serialized by the json module.
+        """
+        kwargs = {
+            'sender': self.__class__, 'source': self.user2,
+            'source_display_name': 'User 2', 'recipient': self.user1,
+            'action': 'Notified', 'category': 'General notification',
+            'obj': 1, 'short_description': 'Short Description',
+            'url': 'http://example.com', 'is_read': False,
+            'extra_data': {'hello': lambda x: 'world'},
+            'channels': ('console',)
+        }
+
+        self.assertRaises(TypeError, notify, **kwargs)
+
+    def test_json_decode(self):
+        """Should return a dictionary back."""
+        notify(
+            source=self.user2, source_display_name='User 2',
+            recipient=self.user1, action='Notified',
+            category='Notification with extra data', obj=1,
+            url='http://example.com', short_description='Short Description',
+            is_read=False, extra_data={'hello': 'world'},
+            channels=('console',)
+        )
+
+        notification = Notification.objects.last()
+
+        self.assertEqual(
+            notification.extra_data, {'hello': 'world'}
+        )
+
+
+class TestListField(TestCase):
+    """Tests for the list field."""
+
+    User = get_user_model()
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create Users."""
+        cls.user1 = cls.User.objects.create_user(
+            username='user1@gmail.com', password='password'
+        )
+
+        cls.user2 = cls.User.objects.create(
+            username='user2@gmail.com', password='password'
+        )
+
+    def test_should_return_list(self):
+        """Should return a list of channels back."""
+        notify(
+            source=self.user2, source_display_name='User 2',
+            recipient=self.user1, action='Notified',
+            category='Notification with extra data', obj=1,
+            url='http://example.com', short_description='Short Description',
+            is_read=False, extra_data={'hello': 'world'},
+            channels=('console', 'console')
+        )
+
+        notification = Notification.objects.last()
+
+        self.assertEqual(
+            notification.to_json()['channels'], ['console', 'console']
+        )

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -2,13 +2,15 @@
 
 import importlib
 
+from . import NotificationError
+from .models import Notification
 from . import default_settings as settings
 
 
 def import_channel(channel_alias):
     """
     helper to import channels aliases from string paths.
-  
+
     raises an AttributeError if a channel can't be found by it's alias
     """
 
@@ -24,3 +26,32 @@ def import_channel(channel_alias):
     package, attr = channel_path.rsplit('.', 1)
 
     return getattr(importlib.import_module(package), attr)
+
+
+def notify(silent=False, **kwargs):
+    """Helper method to send a notification."""
+    from .tasks import send_notification
+
+    notification = Notification(**kwargs)
+
+    # If it's a not a silent notification, save the notification
+    if not silent:
+        notification.save()
+
+    # Send the notification asynchronously with celery
+    send_notification.delay(notification.to_json())
+
+
+def read(notify_id, recipient):
+    """
+    Helper method to read a notification.
+
+    Raises NotificationError if the user doesn't have access
+    to read the notification
+    """
+    notification = Notification.objects.get(id=notify_id)
+
+    if recipient != notification.recipient:
+        raise NotificationError('You cannot read this notification')
+
+    notification.read()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 celery==4.1.0
 coverage==4.3.4
-Django==2.1.5
+Django==2.1.11
 pika==0.11.2
 pytz==2017.2
 uWSGI==2.0.15

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,39 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-import os
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
-def package_files(directory):
-    """Recursively add subfolders and files."""
-    paths = []
-    for (path, _, filenames) in os.walk(directory):
-        for filename in filenames:
-            paths.append(os.path.join('..', path, filename))
-    return paths
+# Package meta-data.
+NAME = 'django-notifs'
+DESCRIPTION = 'Re-usable notification app for Django'
+URL = 'https://github.com/danidee10/django-notifs'
+EMAIL = 'osaetindaniel@gmail.com'
+AUTHOR = 'Osaetin Daniel'
+REQUIRES_PYTHON = '>=3.5.0'
+VERSION = '2.6.2'
 
-EXTRA_FILES = package_files('notifications')
+REQUIRED = ['django', 'pika', 'celery', 'six']
+EXCLUDE = ['notifs', 'tests', '*.tests', '*.tests.*', 'tests.*']
 
 setup(
-    name='django-notifs', version='2.6.2',
-    description='Re-usable notification app for Django',
-    url='https://github.com/danidee10/django-notifs', author='Osaetin Daniel',
-    author_email='osaetindaniel@gmail.com', license='MIT',
-    packages=['notifications'], package_data={'': EXTRA_FILES},
-    install_requires=['django', 'pika', 'celery', 'six'], zip_safe=False
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    long_description=DESCRIPTION,
+    long_description_content_type='text/markdown',
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
+    url=URL,
+    packages=find_packages(exclude=EXCLUDE),
+    install_requires=REQUIRED,
+    license='MIT',
+    classifiers=[
+        # Trove classifiers
+        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'License :: OSI Approved :: All Rights Reserved',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+    ]
 )


### PR DESCRIPTION
Signals have been replaced with similar functions in `notifications.utils` and they'll eventually be removed in `2.6.5`