### PR TITLE
3.0.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ URL = 'https://github.com/danidee10/django-notifs'
 EMAIL = 'osaetindaniel@gmail.com'
 AUTHOR = 'Osaetin Daniel'
 REQUIRES_PYTHON = '>=3.5.0'
-VERSION = '2.6.5'
+VERSION = '3.0.0'
 
 REQUIRED = [
-    'django>=2.0', 'requests==2.25.1', 'django-jsonfield-backport==1.0.3'
+    'django>=2.2', 'requests==2.25.1', 'django-jsonfield-backport==1.0.3'
 ]
 TEST_REQUIRES = ['coverage>=5.4']
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
- add new setting NOTIFICATIONS_DELIVERY_BACKEND
- add new setting NOTIFICATIONS_QUEUE_NAME
- Change default backend to Synchronous (Celery now has to be explicitly configured)
- Create celery backend
- Create Synchronous backend
- Create RQ Backend
- Update installation instructions (Optional dependencies)
- run each channel as a task
- Add retry functionality
- Document NOTIFICATIONS_RETRY = True and NOTIFICATIONS_RETRY_INTERVAL and NOTIFICATIONS_MAX_RETRIES
- Remove NOTIFICATIONS_PAGINATE_BY setting
- Remove NOTIFICATIONS_USE_WEBSOCKET setting
- Remove NOTIFICATIONS_RABBIT_MQ_URL setting
- Rename BasicWebSocket channel to WebSocket channel
- Use Django channels for WebSocket
- Add new setting NOTIFICATIONS_WEBSOCKET_EVENT_NAME
- Add new setting NOTIFICATIONS_WEBSOCKET_URL_PARAM
- django-jsonfield-backport to support JSONField in django < 3.1